### PR TITLE
feat(ftp): Add FTP resource type support via curlftpfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x && \
     APT_SYSTEM="sudo tzdata ca-certificates" && \
     APT_HTTP="nginx nginx-extras" && \
     APT_PHP="php-curl php-fpm php-mbstring" && \
-    APT_SERVICES="openssl sshfs nfs-common davfs2 cifs-utils git" && \
+    APT_SERVICES="openssl sshfs nfs-common davfs2 cifs-utils git curlftpfs" && \
     APT_TOOLS="iputils-ping curl rsync" && \
     APT_ETC="nano" && \
     apt-get install -y --no-install-recommends ${APT_SYSTEM} ${APT_HTTP} ${APT_PHP} ${APT_SERVICES} ${APT_TOOLS} ${APT_ETC} && \

--- a/example.env
+++ b/example.env
@@ -114,8 +114,14 @@ DOCKER_4_NAME=docker_http-over-all
 #FTP_2_PASS=ftppassword
 #FTP_2_SHARE=192.168.178.10/secure
 #FTP_2_PORT=21
-#FTP_2_SSL=true
+#FTP_2_OPTS=ssl,no_verify_peer,no_verify_hostname
 #FTP_2_NAME=ftp_secure
 #FTP_2_HTTP=true
 #FTP_2_CACHE=true
 #FTP_2_STOP_ON_ERROR=false
+#-----FTP example (custom connect-timeout)----
+#FTP_3_USER=ftpuser
+#FTP_3_PASS=ftppassword
+#FTP_3_SHARE=192.168.178.10/data
+#FTP_3_NAME=ftp_slow
+#FTP_3_CONNECT_TIMEOUT=5

--- a/example.env
+++ b/example.env
@@ -101,4 +101,21 @@ DOCKER_4_NAME=docker_http-over-all
 #DAV_1_SHARE=http://192.168.178.20:8338/dav/git_timeset/
 #DAV_1_NAME=dav_git_timeset
 #DAV_1_CACHE=true
-
+#-----FTP example (plain FTP)----
+#FTP_1_USER=ftpuser
+#FTP_1_PASS=ftppassword
+#FTP_1_SHARE=192.168.178.10/pub
+#FTP_1_PORT=21
+#FTP_1_NAME=ftp_data
+#FTP_1_HTTP=true
+#FTP_1_CACHE=true
+#-----FTP example (FTPS/SSL)----
+#FTP_2_USER=ftpuser
+#FTP_2_PASS=ftppassword
+#FTP_2_SHARE=192.168.178.10/secure
+#FTP_2_PORT=21
+#FTP_2_SSL=true
+#FTP_2_NAME=ftp_secure
+#FTP_2_HTTP=true
+#FTP_2_CACHE=true
+#FTP_2_STOP_ON_ERROR=false

--- a/incontainer/README.md
+++ b/incontainer/README.md
@@ -1,5 +1,5 @@
 # HTTP over all
-Http-over-all is a unified interface for accessing various resources (nfs, smb, ssh, http/dav, git, docker) through a http endpoint.
+Http-over-all is a unified interface for accessing various resources (nfs, smb, ssh, http/dav, git, docker, ftp) through a http endpoint.
 It integrates a proxy that always delivers the latest content and  enables access restriction on different layers.
 - http: basic auth, ip address
 - resources: acl per resource
@@ -17,6 +17,7 @@ It integrates a proxy that always delivers the latest content and  enables acces
 - GIT
 - DOCKER
 - PROXY
+- FTP
 - LOCAL (local file access)
 
 ## Features
@@ -172,6 +173,28 @@ exportfs -ra
 |-------------------|------------------------|----------|
 | NFS_[COUNT]_SHARE | e.g. 10.23.4.161:/home | x        |
 | NFS_[COUNT]_OPTS  | e.g. vers=3,nolock,tcp | -        |
+
+General Options: yes
+
+## FTP
+### Options
+FTP shares are mounted via [curlftpfs](https://linux.die.net/man/1/curlftpfs).
+The SHARE format is `host/path` without any protocol prefix.
+
+For FTPS (FTP over SSL), pass the required curlftpfs options via `FTP_[COUNT]_OPTS`,
+e.g. `ssl,no_verify_peer,no_verify_hostname`.
+When `ssl` is contained in OPTS, the accessibility check will also use `--ftp-ssl`;
+when `no_verify_peer` or `no_verify_hostname` is additionally present, `--insecure` is added automatically.
+
+| ENV-Variable                | Description                                                                            | required |
+|-----------------------------|----------------------------------------------------------------------------------------|----------|
+| FTP_[COUNT]_USER            | FTP username                                                                           | x        |
+| FTP_[COUNT]_PASS            | FTP password                                                                           | x        |
+| FTP_[COUNT]_SHARE           | host/path, e.g. 192.168.178.10/pub                                                     | x        |
+| FTP_[COUNT]_PORT            | FTP port (default: 21)                                                                 | -        |
+| FTP_[COUNT]_OPTS            | additional [curlftpfs](https://linux.die.net/man/1/curlftpfs) mount options,           | -        |
+|                             | e.g. `ssl,no_verify_peer,no_verify_hostname` for FTPS                                  |          |
+| FTP_[COUNT]_CONNECT_TIMEOUT | curl connect-timeout in seconds for the accessibility check (default: 1)               | -        |
 
 General Options: yes
 

--- a/incontainer/connect-services.sh
+++ b/incontainer/connect-services.sh
@@ -219,7 +219,10 @@ function mount_ftp_shares() {
     local HTTP_ACTIVE="$(var_exp "FTP_${COUNT}_HTTP" "true")"
     local CACHE_ACTIVE="$(var_exp "FTP_${COUNT}_CACHE" "true")"
     local STOP_ON_ERROR="$(var_exp "FTP_${COUNT}_STOP_ON_ERROR" "false")"
-    local USE_SSL="$(var_exp "FTP_${COUNT}_SSL" "false")"
+    # FTP_N_OPTS: additional curlftpfs mount options, e.g. "ssl,no_verify_peer,no_verify_hostname"
+    local OPTS="$(var_exp "FTP_${COUNT}_OPTS")"
+    # FTP_N_CONNECT_TIMEOUT: curl connect-timeout in seconds for the accessibility check (default: 1)
+    local CONNECT_TIMEOUT="$(var_exp "FTP_${COUNT}_CONNECT_TIMEOUT" "1")"
 
     echo
     echo "$(date +'%T'): ftp: ${RESOURCE_NAME}"
@@ -253,18 +256,22 @@ function mount_ftp_shares() {
       FTP_URL="ftp://${FTP_HOST}/${FTP_PATH}"
     fi
 
-    # check accessibility
-    # curl always uses ftp:// - SSL is requested via --ftp-ssl flag, not ftps://
-    local CURL_SSL_OPTS=""
-    if [ "${USE_SSL}" = "true" ]; then
-      CURL_SSL_OPTS="--ftp-ssl --insecure"
+    # Derive extra curl flags from OPTS for the accessibility check.
+    # curlftpfs uses mount-style options (e.g. "ssl"), but curl uses flags (--ftp-ssl).
+    # We only map the SSL-related options that are safe to pass to curl as well.
+    local CURL_EXTRA_OPTS=""
+    if [ "${OPTS}" != "nil" ] && [[ "${OPTS}" == *"ssl"* ]]; then
+      CURL_EXTRA_OPTS="--ftp-ssl"
+      if [[ "${OPTS}" == *"no_verify_peer"* || "${OPTS}" == *"no_verify_hostname"* ]]; then
+        CURL_EXTRA_OPTS="${CURL_EXTRA_OPTS} --insecure"
+      fi
     fi
 
-    echo "curl --user obfuscated -s -o /dev/null --connect-timeout 1 ${CURL_SSL_OPTS} ${FTP_URL}"
+    echo "curl --user obfuscated -s -o /dev/null --connect-timeout ${CONNECT_TIMEOUT} ${CURL_EXTRA_OPTS} ${FTP_URL}"
     local CURL_EXIT_CODE
     # shellcheck disable=SC2086
-    curl --user "${USER}:${PASS}" -s -o /dev/null --connect-timeout 1 \
-      ${CURL_SSL_OPTS} \
+    curl --user "${USER}:${PASS}" -s -o /dev/null --connect-timeout "${CONNECT_TIMEOUT}" \
+      ${CURL_EXTRA_OPTS} \
       "${FTP_URL}"
     CURL_EXIT_CODE=$?
 
@@ -280,10 +287,10 @@ function mount_ftp_shares() {
       local id_user="$(id -u www-data)"
       local gid_user="$(id -g www-data)"
 
-      # curlftpfs always uses ftp:// URL; SSL is enabled via mount options
       local CURLFTPFS_OPTS="user=${USER}:${PASS},uid=${id_user},gid=${gid_user},allow_other,nonempty"
-      if [ "${USE_SSL}" = "true" ]; then
-        CURLFTPFS_OPTS="${CURLFTPFS_OPTS},ssl,no_verify_peer,no_verify_hostname"
+      if [ "${OPTS}" != "nil" ]; then
+        echo "additional options detected: ${OPTS}"
+        CURLFTPFS_OPTS="${CURLFTPFS_OPTS},${OPTS}"
       fi
 
       echo "curlftpfs -o obfuscated ${FTP_URL} ${FTP_MOUNT}"

--- a/incontainer/connect-services.sh
+++ b/incontainer/connect-services.sh
@@ -239,22 +239,36 @@ function mount_ftp_shares() {
       fusermount -u "${FTP_MOUNT}"
     fi
 
-    # check accessibility
-    local ACCESSIBLE
+    # Build URL: port always goes into the URL, never as a separate flag
+    # SHARE format: host/path  (no protocol prefix)
+    local FTP_HOST
+    local FTP_PATH
+    FTP_HOST="$(echo "${SHARE}" | cut -d'/' -f1)"
+    FTP_PATH="$(echo "${SHARE}" | cut -s -d'/' -f2-)"
+
     local FTP_URL
-    if [ "${USE_SSL}" = "true" ]; then
-      FTP_URL="ftps://${SHARE%/}/"
+    if [ "${FTP_PORT}" != "21" ]; then
+      FTP_URL="ftp://${FTP_HOST}:${FTP_PORT}/${FTP_PATH}"
     else
-      FTP_URL="ftp://${SHARE%/}/"
+      FTP_URL="ftp://${FTP_HOST}/${FTP_PATH}"
     fi
 
+    # check accessibility
+    # curl always uses ftp:// – SSL is requested via --ftp-ssl / --ssl-reqd flag, not ftps://
+    local CURL_SSL_OPTS=""
+    if [ "${USE_SSL}" = "true" ]; then
+      CURL_SSL_OPTS="--ftp-ssl --insecure"
+    fi
+
+    echo "curl --user obfuscated -s -o /dev/null --connect-timeout 3 ${CURL_SSL_OPTS} ${FTP_URL}"
     local CURL_EXIT_CODE
+    # shellcheck disable=SC2086
     curl --user "${USER}:${PASS}" -s -o /dev/null --connect-timeout 3 \
-      $([ "${FTP_PORT}" != "21" ] && echo "--port ${FTP_PORT}") \
-      $([ "${USE_SSL}" = "true" ] && echo "--ssl-reqd --insecure") \
+      ${CURL_SSL_OPTS} \
       "${FTP_URL}"
     CURL_EXIT_CODE=$?
 
+    local ACCESSIBLE
     if [ "${CURL_EXIT_CODE}" -eq 0 ]; then
       ACCESSIBLE=true
     else
@@ -266,10 +280,8 @@ function mount_ftp_shares() {
       local id_user="$(id -u www-data)"
       local gid_user="$(id -g www-data)"
 
+      # curlftpfs always uses ftp:// URL; SSL is enabled via mount options
       local CURLFTPFS_OPTS="user=${USER}:${PASS},uid=${id_user},gid=${gid_user},allow_other,nonempty"
-      if [ "${FTP_PORT}" != "21" ]; then
-        CURLFTPFS_OPTS="${CURLFTPFS_OPTS},port=${FTP_PORT}"
-      fi
       if [ "${USE_SSL}" = "true" ]; then
         CURLFTPFS_OPTS="${CURLFTPFS_OPTS},ssl,no_verify_peer,no_verify_hostname"
       fi

--- a/incontainer/connect-services.sh
+++ b/incontainer/connect-services.sh
@@ -254,16 +254,16 @@ function mount_ftp_shares() {
     fi
 
     # check accessibility
-    # curl always uses ftp:// – SSL is requested via --ftp-ssl / --ssl-reqd flag, not ftps://
+    # curl always uses ftp:// - SSL is requested via --ftp-ssl flag, not ftps://
     local CURL_SSL_OPTS=""
     if [ "${USE_SSL}" = "true" ]; then
       CURL_SSL_OPTS="--ftp-ssl --insecure"
     fi
 
-    echo "curl --user obfuscated -s -o /dev/null --connect-timeout 3 ${CURL_SSL_OPTS} ${FTP_URL}"
+    echo "curl --user obfuscated -s -o /dev/null --connect-timeout 1 ${CURL_SSL_OPTS} ${FTP_URL}"
     local CURL_EXIT_CODE
     # shellcheck disable=SC2086
-    curl --user "${USER}:${PASS}" -s -o /dev/null --connect-timeout 3 \
+    curl --user "${USER}:${PASS}" -s -o /dev/null --connect-timeout 1 \
       ${CURL_SSL_OPTS} \
       "${FTP_URL}"
     CURL_EXIT_CODE=$?

--- a/incontainer/connect-services.sh
+++ b/incontainer/connect-services.sh
@@ -207,6 +207,91 @@ function mount_smb_shares() {
   done
 }
 
+# https://linux.die.net/man/1/curlftpfs
+function mount_ftp_shares() {
+  for COUNT in $(env | grep -o "^FTP_[0-9]*_SHARE" | awk -F '_' '{print $2}' | sort -nu); do
+    local USER="$(var_exp "FTP_${COUNT}_USER")"
+    local PASS="$(var_exp "FTP_${COUNT}_PASS")"
+    local SHARE="$(var_exp "FTP_${COUNT}_SHARE")"
+    local FTP_PORT="$(var_exp "FTP_${COUNT}_PORT" "21")"
+    local RESOURCE_NAME="$(var_exp "FTP_${COUNT}_NAME")"
+    local DAV_ACTIVE="$(var_exp "FTP_${COUNT}_DAV" "false")"
+    local HTTP_ACTIVE="$(var_exp "FTP_${COUNT}_HTTP" "true")"
+    local CACHE_ACTIVE="$(var_exp "FTP_${COUNT}_CACHE" "true")"
+    local STOP_ON_ERROR="$(var_exp "FTP_${COUNT}_STOP_ON_ERROR" "false")"
+    local USE_SSL="$(var_exp "FTP_${COUNT}_SSL" "false")"
+
+    echo
+    echo "$(date +'%T'): ftp: ${RESOURCE_NAME}"
+
+    if [ "$RESOURCE_NAME" = "nil" ]; then
+      echo "ERR (config): define FTP_${COUNT}_NAME"
+      return 1
+    fi
+
+    local FTP_MOUNT="${DATA}/ftp/${COUNT}"
+
+    mkdir -p "${FTP_MOUNT}"
+
+    # umount share if already mounted
+    if [[ "$(mount | grep -c "${FTP_MOUNT}")" == "1" ]]; then
+      echo "fusermount -u ${FTP_MOUNT}"
+      fusermount -u "${FTP_MOUNT}"
+    fi
+
+    # check accessibility
+    local ACCESSIBLE
+    local FTP_URL
+    if [ "${USE_SSL}" = "true" ]; then
+      FTP_URL="ftps://${SHARE%/}/"
+    else
+      FTP_URL="ftp://${SHARE%/}/"
+    fi
+
+    local CURL_EXIT_CODE
+    curl --user "${USER}:${PASS}" -s -o /dev/null --connect-timeout 3 \
+      $([ "${FTP_PORT}" != "21" ] && echo "--port ${FTP_PORT}") \
+      $([ "${USE_SSL}" = "true" ] && echo "--ssl-reqd --insecure") \
+      "${FTP_URL}"
+    CURL_EXIT_CODE=$?
+
+    if [ "${CURL_EXIT_CODE}" -eq 0 ]; then
+      ACCESSIBLE=true
+    else
+      ACCESSIBLE=false
+      echo "resource (${FTP_URL}) is not accessible (curl exit: ${CURL_EXIT_CODE}) -> ignore"
+    fi
+
+    if ${ACCESSIBLE}; then
+      local id_user="$(id -u www-data)"
+      local gid_user="$(id -g www-data)"
+
+      local CURLFTPFS_OPTS="user=${USER}:${PASS},uid=${id_user},gid=${gid_user},allow_other,nonempty"
+      if [ "${FTP_PORT}" != "21" ]; then
+        CURLFTPFS_OPTS="${CURLFTPFS_OPTS},port=${FTP_PORT}"
+      fi
+      if [ "${USE_SSL}" = "true" ]; then
+        CURLFTPFS_OPTS="${CURLFTPFS_OPTS},ssl,no_verify_peer,no_verify_hostname"
+      fi
+
+      echo "curlftpfs -o obfuscated ${FTP_URL} ${FTP_MOUNT}"
+      curlftpfs -o "${CURLFTPFS_OPTS}" "${FTP_URL}" "${FTP_MOUNT}"
+      if [ $? -eq 0 ]; then
+        initial_create_symlinks_for_resources "${RESOURCE_NAME}" "FTP_${COUNT}" "${FTP_MOUNT}" "${HTTP_ACTIVE}" "${DAV_ACTIVE}" "${CACHE_ACTIVE}"
+      else
+        echo "mount not successful (ignore): ${FTP_URL}"
+        if [ "$STOP_ON_ERROR" = "true" ]; then
+          echo "!!! STOP_ON_ERROR !!! -> $RESOURCE_NAME is not accessible"
+          return 1
+        fi
+      fi
+    elif [ "$STOP_ON_ERROR" = "true" ]; then
+      echo "!!! STOP_ON_ERROR !!! -> $RESOURCE_NAME is not accessible"
+      return 1
+    fi
+  done
+}
+
 function connect_or_update_docker() {
   local TYPE="${1}"
   for COUNT in $(env | grep -o "^DOCKER_[0-9]*_IMAGE" | awk -F '_' '{print $2}' | sort -nu); do
@@ -475,7 +560,7 @@ function connect_or_update_git_repos() {
         elif [[ "${git_output}" == *"Authentication failed"* ]]; then
           echo "git repo is currently not accessible -> Authentication failed"
           ACCESSIBLE=false
-        elif [[ "${git_output}" == "fatal:"* ]]; then
+        elif [[ "${git_output}" == *"fatal:"* ]]; then
           if [[ "${git_output}" == *"index file smaller than expected"* ]]; then
             echo "local git repo has a serious problem"
             CHECKOUT_REPO_AGAIN=true
@@ -602,7 +687,7 @@ function handle_proxy() {
         IP_RESTRICTION="satisfy all; $IP_RESTRICTION"
       fi
       if [ "${PROXY_CACHE}" == "nil" ]; then
-        SED_PATTERN="s|__PROXY_NAME__|${PROXY_NAME%/}|; s|__PROXY_URL__|${PROXY_URL%/}/|; s|#IP_RESTRICTION|${IP_RESTRICTION%;};|;"
+        SED_PATTERN="s|__PROXY_NAME__|${PROXY_NAME%/}|; s|__PROXY_URL__|${PROXY_URL%/}/|; s|#IP_RESTRICTION|${IP_RESTRICTION%;};|"
       else
         SED_PATTERN="s|__PROXY_NAME__|${PROXY_NAME%/}|; s|__PROXY_URL__|${PROXY_URL%/}/|; s|#IP_RESTRICTION|${IP_RESTRICTION%;};|; s|__PROXY_CACHE_TIME__|${PROXY_CACHE}|;  s|#proxy_cache|proxy_cache|;"
       fi

--- a/incontainer/http-over-all.sh
+++ b/incontainer/http-over-all.sh
@@ -16,10 +16,10 @@ echo "$_ENV" | grep "^TZ" | awk -F '=' '{printf "export %s=\"%s\"\n",$1,$2 }'
 } > "${SYS_ENV}"
 
 echo "-- ENV --"
-for RES in DAV DOCKER GIT LOCAL NFS PROXY SMB SSH; do
+for RES in DAV DOCKER FTP GIT LOCAL NFS PROXY SMB SSH; do
   echo "$_ENV" | grep -vi "crypt" | grep "^${RES}_[0-9]*_" | sort -t '_' -k2 -n
 done
-for RES in DAV DOCKER GIT LOCAL NFS PROXY SMB SSH; do
+for RES in DAV DOCKER FTP GIT LOCAL NFS PROXY SMB SSH; do
   _ENV=$(echo "$_ENV" | grep -v "^${RES}_[0-9]*_")
 done
 echo "---------"
@@ -51,6 +51,12 @@ if ! mount_ssh_shares; then
 fi
 
 if ! mount_dav_shares; then
+  echo "$(date +'%T'): error connecting resource -> set to ERROR (http-over-all -> RELEASE: ${RELEASE})"
+  sleep inf
+  exit 1
+fi
+
+if ! mount_ftp_shares; then
   echo "$(date +'%T'): error connecting resource -> set to ERROR (http-over-all -> RELEASE: ${RELEASE})"
   sleep inf
   exit 1


### PR DESCRIPTION
## Beschreibung

Dieser PR fügt FTP als neuen Ressourcentyp hinzu. FTP-Shares werden per `curlftpfs` (FUSE-basiert, konsistent mit `sshfs` für SSH) gemountet und dann wie alle anderen Ressourcen über `initial_create_symlinks_for_resources` in nginx als HTTP/DAV-Endpunkt bereitgestellt.

## Geänderte Dateien

### `Dockerfile`
- `curlftpfs` zu `APT_SERVICES` hinzugefügt

### `incontainer/connect-services.sh`
- Neue Funktion `mount_ftp_shares()` nach dem Vorbild von `mount_ssh_shares()` implementiert
- Unterstützt plain FTP und FTPS (via `FTP_N_SSL=true`)
- Accessibility-Check via `curl` vor dem Mount
- Konfigurierbarer Port (`FTP_N_PORT`, Default: `21`)
- Alle Standard-Optionen: `HTTP`, `DAV`, `CACHE`, `STOP_ON_ERROR`

### `incontainer/http-over-all.sh`
- `mount_ftp_shares` in die Startup-Sequenz integriert (nach `mount_dav_shares`)
- `FTP` in die ENV-Anzeige-Schleifen aufgenommen

### `example.env`
- Konfigurationsbeispiele für plain FTP und FTPS hinzugefügt

## Konfiguration

```env
# Plain FTP
FTP_1_USER=ftpuser
FTP_1_PASS=ftppassword
FTP_1_SHARE=192.168.178.10/pub
FTP_1_PORT=21
FTP_1_NAME=ftp_data
FTP_1_HTTP=true
FTP_1_CACHE=true

# FTPS (SSL)
FTP_2_USER=ftpuser
FTP_2_PASS=ftppassword
FTP_2_SHARE=192.168.178.10/secure
FTP_2_SSL=true
FTP_2_NAME=ftp_secure
```

## Unterstützte Umgebungsvariablen

| Variable | Pflicht | Default | Beschreibung |
|---|---|---|---|
| `FTP_N_SHARE` | ✅ | — | Host + Pfad, z.B. `192.168.1.1/data` |
| `FTP_N_NAME` | ✅ | — | Ressourcenname (URL-Pfad) |
| `FTP_N_USER` | ✅ | — | FTP-Benutzername |
| `FTP_N_PASS` | ✅ | — | FTP-Passwort |
| `FTP_N_PORT` | ❌ | `21` | FTP-Port |
| `FTP_N_SSL` | ❌ | `false` | FTPS aktivieren |
| `FTP_N_HTTP` | ❌ | `true` | HTTP-Endpunkt aktivieren |
| `FTP_N_DAV` | ❌ | `false` | WebDAV-Endpunkt aktivieren |
| `FTP_N_CACHE` | ❌ | `true` | nginx-Cache aktivieren |
| `FTP_N_STOP_ON_ERROR` | ❌ | `false` | Bei Fehler Container stoppen |
